### PR TITLE
fix(package): fix esm and cjs types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,5 +35,8 @@ jobs:
       - name: Run module tests
         run: npm run test:esm
 
-      - name: Build artifacts
+      - name: Build package
         run: npm run build
+
+      - name: Lint package
+        run: npm run lint:package

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 npm run build
 npm run test:ci
+npm run test:esm
+npm run lint:package
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -1847,14 +1847,15 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
-      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
+        "picomatch": "^4.0.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1873,18 +1874,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.4",
@@ -8286,6 +8275,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
+      "license": "0BSD",
       "optional": true
     },
     "node_modules/type-check": {
@@ -8404,6 +8394,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10161,26 +10152,20 @@
       }
     },
     "@rollup/pluginutils": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
-      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
       "dev": true,
       "requires": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
+        "picomatch": "^4.0.2"
       },
       "dependencies": {
         "estree-walker": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
           "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
-        },
-        "picomatch": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,18 +11,19 @@
       "default": "./esm/index.mjs"
     },
     "require": {
-      "types": "./cjs/index.d.ts",
+      "types": "./cjs/index.d.cts",
       "default": "./cjs/index.js"
     }
   },
   "scripts": {
     "build": "run-s build:*",
-    "build:cjs": "rollup --config rollup.cjs.config.mjs --failAfterWarnings",
-    "build:esm": "rollup --config rollup.esm.config.mjs --failAfterWarnings",
+    "build:cjs": "rollup --config rollup.cjs.config.mjs --failAfterWarnings && cp index.d.ts cjs/index.d.cts",
+    "build:esm": "rollup --config rollup.esm.config.mjs --failAfterWarnings && cp index.d.ts esm/index.d.mts",
     "build:umd": "rollup --config rollup.umd.config.mjs --failAfterWarnings",
     "clean": "rm -rf cjs dist esm",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
+    "lint:package": "publint",
     "prepare": "husky",
     "prepublishOnly": "npm run lint && npm run build && npm test",
     "test": "jest --colors --testPathIgnorePatterns=test/index.test.mjs",


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(package): fix esm and cjs types

Caused by #398

## What is the current behavior?

https://publint.dev/inline-style-parser@0.2.5

Errors:
1. `pkg.exports.import.types` is `./esm/index.d.mts` but the file does not exist.
2. `pkg.exports.require.types` is `./cjs/index.d.ts` but the file does not exist.
3. `pkg.types` is `./esm/index.d.mts` but the file does not exist.

## What is the new behavior?

Copied `esm/index.d.mts` and `cjs/index.d.cts` during build and added publint

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation