### PR TITLE
fix: parse semicolon and parenthesis inside quoted url

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var WHITESPACE_REGEX = /^\s*/;
 // declaration
 var PROPERTY_REGEX = /^(\*?[-#/*\\\w]+(\[[0-9a-z_-]+\])?)\s*/;
 var COLON_REGEX = /^:\s*/;
-var VALUE_REGEX = /^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^)]*?\)|[^};])+)/;
+var VALUE_REGEX = /^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^};])+)/;
 var SEMICOLON_REGEX = /^[;\s]*/;
 
 // https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Polyfill

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -84,6 +84,48 @@ exports[`inline-style-parser parses multiple declarations 1`] = `
 ]
 `;
 
+exports[`inline-style-parser parses semicolon and parenthesis inside double quoted url 1`] = `
+[
+  {
+    "position": Position {
+      "end": {
+        "column": 35,
+        "line": 1,
+      },
+      "source": undefined,
+      "start": {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "property": "background",
+    "type": "declaration",
+    "value": "url("a)b;c") no-repeat",
+  },
+]
+`;
+
+exports[`inline-style-parser parses semicolon and parenthesis inside single quoted url 1`] = `
+[
+  {
+    "position": Position {
+      "end": {
+        "column": 35,
+        "line": 1,
+      },
+      "source": undefined,
+      "start": {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "property": "background",
+    "type": "declaration",
+    "value": "url('a)b;c') no-repeat",
+  },
+]
+`;
+
 exports[`inline-style-parser parses single declaration 1`] = `
 [
   {

--- a/test/data.js
+++ b/test/data.js
@@ -60,6 +60,16 @@ const snapshots = [
 
   ['parses single declaration', 'background-color: #C0FFEE;'],
 
+  // https://github.com/remarkablemark/inline-style-parser/issues/550
+  [
+    'parses semicolon and parenthesis inside double quoted url',
+    'background: url("a)b;c") no-repeat;'
+  ],
+  [
+    'parses semicolon and parenthesis inside single quoted url',
+    "background: url('a)b;c') no-repeat;"
+  ],
+
   [
     'parses multiple declarations',
     `

--- a/test/data.js
+++ b/test/data.js
@@ -30,7 +30,11 @@ const cases = [
   'content: "Lorem ipsum";',
   'content: "foo: bar;";',
   'background-image: url(http://example.com/img.png)',
-  'background: #123456 url("https://foo.bar/image.png?v=2")',
+  'background: #123456 url("https://example.com/img.png?v=2&a=b")',
+  'background-image: url("http://example.com/img.png")',
+  "background-image: url('http://example.com/img.png')",
+  'background: url(http://example.com/img.png) no-repeat',
+  'background: url("data:image/svg+xml,<svg/>")',
 
   // vendor prefixes
   'background: -webkit-linear-gradient(90deg, black, #111)',


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Bug fix: the parser fails when a quoted `url()` contains `)` and `;` inside the string, which is common in SVG data URLs.

Related to https://github.com/remarkablemark/style-to-object/issues/112

## What is the current behavior?

Fixes #550. `inlineStyleParser` throws `property missing ':'` when parsing a value like:

```js
inlineStyleParser('background: url("a)b;c") no-repeat;');
```

This also affects real-world SVG data URLs that contain nested `url(...)` and semicolons in attributes like `animateTransform values='...;...'`.

## What is the new behavior?

Quoted `url()` values are parsed as a single value, including any `)` or `;` inside the quotes.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->
