### PR TITLE
refactor: remove dead code and add 100% test branch coverage

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,16 +141,13 @@ export default function (style, options) {
   /**
    * Parse comments.
    *
-   * @param {Object[]} [rules]
+   * @param {Object[]} rules
    * @return {Object[]}
    */
   function comments(rules) {
     var c;
-    rules = rules || [];
     while ((c = comment())) {
-      if (c !== false) {
-        rules.push(c);
-      }
+      rules.push(c);
     }
     return rules;
   }
@@ -237,10 +234,8 @@ export default function (style, options) {
     // declarations
     var decl;
     while ((decl = declaration())) {
-      if (decl !== false) {
-        decls.push(decl);
-        comments(decls);
-      }
+      decls.push(decl);
+      comments(decls);
     }
 
     return decls;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`inline-style-parser parses declaration with comment-only value 1`] = `
+[
+  {
+    "position": Position {
+      "end": {
+        "column": 17,
+        "line": 1,
+      },
+      "source": undefined,
+      "start": {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "property": "color",
+    "type": "declaration",
+    "value": "",
+  },
+]
+`;
+
 exports[`inline-style-parser parses multiple declarations 1`] = `
 [
   {

--- a/test/data.js
+++ b/test/data.js
@@ -81,7 +81,9 @@ const snapshots = [
       content  :  " "  ; /* comment */
       foo:bar;-o-transition:all .5s
     `
-  ]
+  ],
+
+  ['parses declaration with comment-only value', 'color: /* red */;']
 ];
 
 const errors = [


### PR DESCRIPTION
## What is the motivation for this pull request?

Refactor to remove dead code and achieve 100% test branch coverage.

## What is the current behavior?

- `comments()` had an unreachable `if (c !== false)` guard — `comment()` never returns `false`
- `declarations()` had an unreachable `if (decl !== false)` guard — `declaration()` never returns `false`
- `comments()` had an unreachable `rules = rules || []` fallback — it is always called with a `rules` array argument
- `trim()` falsy branch was untested — no test covered a declaration whose value is entirely a CSS comment

Branch coverage was 89.18%.

## What is the new behavior?

- Removed three dead code branches from `index.js`
- Added snapshot test case `'parses declaration with comment-only value'` (e.g. `color: /* red */;`) to cover the `trim('')` branch

Branch coverage is now 100%.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation