### PR TITLE
fix: parse unquoted `url()` values containing semicolons

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var WHITESPACE_REGEX = /^\s*/;
 // declaration
 var PROPERTY_REGEX = /^(\*?[-#/*\\\w]+(\[[0-9a-z_-]+\])?)\s*/;
 var COLON_REGEX = /^:\s*/;
-var VALUE_REGEX = /^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^};])+)/;
+var VALUE_REGEX =
+  /^((?:'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|url\((?:'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|[^)]*)\)|[^};])+)/;
 var SEMICOLON_REGEX = /^[;\s]*/;
 
 // https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Polyfill

--- a/test/data.js
+++ b/test/data.js
@@ -35,6 +35,7 @@ const cases = [
   "background-image: url('http://example.com/img.png')",
   'background: url(http://example.com/img.png) no-repeat',
   'background: url("data:image/svg+xml,<svg/>")',
+  'background: url(data:image/png; base64,abc+/=)',
 
   // vendor prefixes
   'background: -webkit-linear-gradient(90deg, black, #111)',


### PR DESCRIPTION
## What is the motivation for this pull request?

Bug fix: the parser failed to parse unquoted `url()` values that contain semicolons, such as data URIs (e.g. `url(data:image/png; base64,...)`).

## What is the current behavior?

Parsing `background: url(data:image/png; base64,...)` throws `property missing ':'` because `VALUE_REGEX` stops matching at the `;` inside the unquoted `url()`, treating the remainder as a new property declaration.

## What is the new behavior?

`VALUE_REGEX` now includes a `url(...)` alternative that consumes the entire unquoted `url()` token (including any `;` inside it) before falling back to character-by-character matching.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation