### PR TITLE
fix: replace `COMMENT_REGEX` to prevent ReDoS vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // http://www.w3.org/TR/CSS21/grammar.html
 // https://github.com/visionmedia/css-parse/pull/49#issuecomment-30088027
-var COMMENT_REGEX = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
+var COMMENT_REGEX = /\/\*[\s\S]*?\*\//g;
 
 var NEWLINE_REGEX = /\n/g;
 var WHITESPACE_REGEX = /^\s*/;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // http://www.w3.org/TR/CSS21/grammar.html
 // https://github.com/visionmedia/css-parse/pull/49#issuecomment-30088027
-var COMMENT_REGEX = /\/\*[\s\S]*?\*\//g;
+var COMMENT_REGEX = /\/\*(?:[^*]|\*(?!\/))*\*\//g;
 
 var NEWLINE_REGEX = /\n/g;
 var WHITESPACE_REGEX = /^\s*/;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`inline-style-parser parses adversarial comment input with mixed star-slash repetitions without backtracking 1`] = `
+[
+  {
+    "position": Position {
+      "end": {
+        "column": 26,
+        "line": 1,
+      },
+      "source": undefined,
+      "start": {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "property": "color",
+    "type": "declaration",
+    "value": "red",
+  },
+]
+`;
+
+exports[`inline-style-parser parses adversarial comment input without backtracking 1`] = `
+[
+  {
+    "position": Position {
+      "end": {
+        "column": 25,
+        "line": 1,
+      },
+      "source": undefined,
+      "start": {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "property": "color",
+    "type": "declaration",
+    "value": "red",
+  },
+]
+`;
+
 exports[`inline-style-parser parses declaration with comment-only value 1`] = `
 [
   {

--- a/test/data.js
+++ b/test/data.js
@@ -84,7 +84,15 @@ const snapshots = [
     `
   ],
 
-  ['parses declaration with comment-only value', 'color: /* red */;']
+  ['parses declaration with comment-only value', 'color: /* red */;'],
+  [
+    'parses adversarial comment input without backtracking',
+    'color: /**)))**)))**/red;'
+  ],
+  [
+    'parses adversarial comment input with mixed star-slash repetitions without backtracking',
+    'color: /**)*)/**)**)*/red;'
+  ]
 ];
 
 const errors = [


### PR DESCRIPTION
## What is the motivation for this pull request?

Bug fix: `COMMENT_REGEX` used a nested quantifier pattern that is vulnerable to polynomial backtracking (ReDoS) on adversarial input strings.

## What is the current behavior?

The pattern `/\/\*[^*]*\*+([^/*][^*]*\*+)*\//g` has nested quantifiers that can cause polynomial backtracking on strings starting with `/**` with many repetitions of `)\/**`, triggering a CodeQL high-severity alert: _Polynomial regular expression used on uncontrolled data_.

## What is the new behavior?

`COMMENT_REGEX` is replaced with `/\/\*[\s\S]*?\*\//g`, a lazy match with no nested quantifiers that eliminates the backtracking risk.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation